### PR TITLE
Compile fix for VS 2015

### DIFF
--- a/source/widgetzeug/source/ColorSchemeGraphicsItemGroup.cpp
+++ b/source/widgetzeug/source/ColorSchemeGraphicsItemGroup.cpp
@@ -21,7 +21,7 @@ ColorSchemeGraphicsItemGroup::ColorSchemeGraphicsItemGroup(
     const DpiAwareGraphicsView * view)
 : m_label{ new QGraphicsTextItem(identifier, this) }
 , m_view{ view }
-, m_minClasses{ std::numeric_limits<int>::max() }
+, m_minClasses{ std::numeric_limits<uint>::max() }
 , m_maxClasses{ 0 }
 {
     m_label->setRotation(-90);


### PR DESCRIPTION
Fix Error C2397: conversion from 'std::numeric_limits<int>::_Ty' to 'uint' requires a narrowing conversion