### PR TITLE
DockableScrollAreaWidget: expose stretch factor

### DIFF
--- a/source/widgetzeug/include/widgetzeug/DockableScrollAreaWidget.h
+++ b/source/widgetzeug/include/widgetzeug/DockableScrollAreaWidget.h
@@ -55,7 +55,7 @@ public:
       * Appends the widget to the vertical layout of this dock widget, thereby wrapping the 
       * widget inside a QGroupWidget and using the widgets window title as the groupbox's title.
       */
-    void addWidget(QWidget * widget);
+    void addWidget(QWidget * widget, int stretch = 0);
 
 protected:
 

--- a/source/widgetzeug/source/DockableScrollAreaWidget.cpp
+++ b/source/widgetzeug/source/DockableScrollAreaWidget.cpp
@@ -34,7 +34,7 @@ DockableScrollAreaWidget::DockableScrollAreaWidget(QWidget * parent, Qt::WindowF
 {
 }
 
-void DockableScrollAreaWidget::addWidget(QWidget * widget)
+void DockableScrollAreaWidget::addWidget(QWidget * widget, int stretch)
 {
     if (!widget)
         return;
@@ -47,7 +47,7 @@ void DockableScrollAreaWidget::addWidget(QWidget * widget)
     group->layout()->addWidget(widget);
     group->layout()->setContentsMargins(0, 0, 0, 0);
 
-    m_vbox->insertWidget(m_vbox->count() - 1, group);
+    m_vbox->insertWidget(m_vbox->count() - 1, group, stretch);
 }
 
 } // namespace widgetzeug


### PR DESCRIPTION
Useful for widgets (e.g., `PropertyBrowser`) that can make use of extra space, if available.