### PR TITLE
Fix warnings

### DIFF
--- a/source/loggingzeug/source/formatString.cpp
+++ b/source/loggingzeug/source/formatString.cpp
@@ -45,6 +45,8 @@ void parseFormat(std::ostream& stream, const char*& format)
 			case 'i':
 				stream << std::internal;
 				break;
+			default:
+				break;
 		}
 	}
 
@@ -76,6 +78,8 @@ void parseFormat(std::ostream& stream, const char*& format)
 			case '0':
 				stream << std::setfill('0');
 				break;
+			default:
+				break;
 		}
 	}
 
@@ -96,6 +100,8 @@ void parseFormat(std::ostream& stream, const char*& format)
 				break;
 			case 'e':
 				stream << std::scientific;
+				break;
+			default:
 				break;
 		}
 	}
@@ -145,6 +151,8 @@ void parseFormat(std::ostream& stream, const char*& format)
 				break;
 			case 'x':
 				stream << std::hex;
+				break;
+			default:
 				break;
 		}
 	}

--- a/source/propertyguizeug/source/ColorButton.cpp
+++ b/source/propertyguizeug/source/ColorButton.cpp
@@ -63,7 +63,7 @@ void ColorButton::setColor(const QColor & color)
 	updateColor();
 }
 
-void ColorButton::mousePressEvent(QMouseEvent * event)
+void ColorButton::mousePressEvent(QMouseEvent * /*event*/)
 {
     emit pressed();
 }

--- a/source/propertyguizeug/source/LongLongSpinBox.cpp
+++ b/source/propertyguizeug/source/LongLongSpinBox.cpp
@@ -145,7 +145,7 @@ qlonglong LongLongSpinBox::valueFromText(const QString & text)
 
 qlonglong LongLongSpinBox::validateAndInterpret(
     const QString & input, 
-    int & pos, 
+    int & /*pos*/, 
     QValidator::State & state) const
 {
     qlonglong num = m_min;

--- a/source/propertyguizeug/source/PropertyBrowser.cpp
+++ b/source/propertyguizeug/source/PropertyBrowser.cpp
@@ -72,7 +72,7 @@ void PropertyBrowser::setAlwaysExpandGroups(bool b)
     m_alwaysExpandGroups = b;
 }
 
-void PropertyBrowser::showEvent(QShowEvent * event)
+void PropertyBrowser::showEvent(QShowEvent * /*event*/)
 {    
     auto window = windowHandle();
     

--- a/source/propertyguizeug/source/PropertyDelegate.cpp
+++ b/source/propertyguizeug/source/PropertyDelegate.cpp
@@ -70,7 +70,7 @@ QWidget * PropertyDelegate::createEditor(QWidget * parent,
 }
 
 void PropertyDelegate::updateEditorGeometry(QWidget * editor, const QStyleOptionViewItem & option,
-    const QModelIndex & index) const
+    const QModelIndex & /*index*/) const
 {
     editor->setGeometry(option.rect);
 }

--- a/source/propertyguizeug/source/PropertyModel.cpp
+++ b/source/propertyguizeug/source/PropertyModel.cpp
@@ -121,7 +121,7 @@ Qt::ItemFlags PropertyModel::flags(const QModelIndex & index) const
     return flags;
 }
 
-QVariant PropertyModel::headerData(int section, Qt::Orientation orientation, int role) const
+QVariant PropertyModel::headerData(int section, Qt::Orientation /*orientation*/, int role) const
 {
     if (role == Qt::DisplayRole) {
         if (section == 0)

--- a/source/propertyguizeug/source/TransparencyBackgroundBrush.hpp
+++ b/source/propertyguizeug/source/TransparencyBackgroundBrush.hpp
@@ -24,4 +24,4 @@ inline const QBrush TransparencyBackgroundBrush()
 		}
 
 	return QBrush(backgroundImage);
-};
+}

--- a/source/propertyguizeug/source/ULongLongSpinBox.cpp
+++ b/source/propertyguizeug/source/ULongLongSpinBox.cpp
@@ -147,7 +147,7 @@ qulonglong ULongLongSpinBox::valueFromText(const QString & text)
     
 qulonglong ULongLongSpinBox::validateAndInterpret(
     const QString & input, 
-    int & pos, 
+    int & /*pos*/, 
     QValidator::State & state) const
 {
     qulonglong num = m_min;

--- a/source/reflectionzeug/source/property/AbstractProperty.cpp
+++ b/source/reflectionzeug/source/property/AbstractProperty.cpp
@@ -32,7 +32,7 @@ std::string AbstractProperty::name() const
     return m_name;
 }
 
-void AbstractProperty::accept(AbstractVisitor * visitor)
+void AbstractProperty::accept(AbstractVisitor * /*visitor*/)
 {
 }
 

--- a/source/reflectionzeug/source/tools/JSONReader.cpp
+++ b/source/reflectionzeug/source/tools/JSONReader.cpp
@@ -347,7 +347,7 @@ bool JSONReader::readString()
     return c == '"';
 }
 
-bool JSONReader::readObject(Token & tokenStart)
+bool JSONReader::readObject(Token & /*tokenStart*/)
 {
     Token tokenName;
     std::string name;
@@ -395,7 +395,7 @@ bool JSONReader::readObject(Token & tokenStart)
     return addErrorAndRecover("Missing '}' or object member name", tokenName, TokenObjectEnd);
 }
 
-bool JSONReader::readArray(Token & tokenStart)
+bool JSONReader::readArray(Token & /*tokenStart*/)
 {
     currentValue() = Variant::array();
     skipSpaces();

--- a/source/scriptzeug/source/backend-duktape/DuktapeScriptContext.cpp
+++ b/source/scriptzeug/source/backend-duktape/DuktapeScriptContext.cpp
@@ -310,12 +310,12 @@ static Variant getPropertyValue(AbstractProperty * property)
     }
 
     // String
-    else if (AbstractStringInterface * prop = dynamic_cast< AbstractStringInterface * >(property) ) {
+    else if (nullptr != dynamic_cast< AbstractStringInterface * >(property) ) {
         value = Variant(property->toString());
     }
 
     // FilePath
-    else if (Property<FilePath> * prop = dynamic_cast< Property<FilePath> * >(property) ) {
+    else if (nullptr != dynamic_cast< Property<FilePath> * >(property) ) {
         value = Variant(property->toString());
     }
 

--- a/source/tests/reflectionzeug-test/CMakeLists.txt
+++ b/source/tests/reflectionzeug-test/CMakeLists.txt
@@ -8,41 +8,32 @@ set(target reflectionzeug-test)
 message(STATUS "Test ${target}")
 
 
+# Generate Property Instanciation Tests
+set(testdir ${CMAKE_SOURCE_DIR}/source/tests/reflectionzeug-test)
+set(filelist ${testdir}/instanciationTestsFiles.txt)
+add_custom_target("generatePropertyTests" COMMAND python ${testdir}/generateInstanciationTests.py ${testdir} ${filelist})
+
+
 # 
 # Sources
 # 
 
 set(sources
     main.cpp
-    # Color_test.cpp
-    
-    propertyInstanciationTests/PropertyInstanciationBool_test.cpp
-    propertyInstanciationTests/PropertyInstanciationFloat_test.cpp
-    propertyInstanciationTests/PropertyInstanciationDouble_test.cpp
-    propertyInstanciationTests/PropertyInstanciationInt8_T_test.cpp
-    propertyInstanciationTests/PropertyInstanciationUint8_T_test.cpp
-    propertyInstanciationTests/PropertyInstanciationInt16_T_test.cpp
-    propertyInstanciationTests/PropertyInstanciationUint16_T_test.cpp
-    propertyInstanciationTests/PropertyInstanciationInt32_T_test.cpp
-    propertyInstanciationTests/PropertyInstanciationUint32_T_test.cpp
-    propertyInstanciationTests/PropertyInstanciationInt64_T_test.cpp
-    propertyInstanciationTests/PropertyInstanciationUint64_T_test.cpp
-    propertyInstanciationTests/PropertyInstanciationString_test.cpp
-    propertyInstanciationTests/PropertyInstanciationVariant_test.cpp
-    propertyInstanciationTests/PropertyInstanciationBoolArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationFloatArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationDoubleArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationInt8_TArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationUint8_TArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationInt16_TArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationUint16_TArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationInt32_TArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationUint32_TArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationInt64_TArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationUint64_TArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationStringArray_test.cpp
-    propertyInstanciationTests/PropertyInstanciationVariantArray_test.cpp
 )
+
+#
+# Add generated instanciation tests to sources
+#
+if(EXISTS ${filelist})
+    FILE(READ ${filelist} contents)
+    STRING(REGEX REPLACE ";" "\\\\;" contents "${contents}")
+    STRING(REGEX REPLACE "\n" ";" contents "${contents}")
+    set(sources
+        ${sources}
+        ${contents}
+    )
+endif()
 
 
 # 

--- a/source/tests/reflectionzeug-test/generateInstanciationTests.py
+++ b/source/tests/reflectionzeug-test/generateInstanciationTests.py
@@ -39,7 +39,7 @@ ${DATATYPE} staticGetter()
     return ${DATATYPE}();
 }
 
-void staticSetter(${DATATYPE} value)
+void staticSetter(${DATATYPE} /*value*/)
 {
 }
 }
@@ -50,7 +50,7 @@ void staticSetter(${DATATYPE} value)
 TEST_F(PropertyInstance${CAPITALDATATYPE}_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return ${DATATYPE}();};
-    auto set = [] (const ${DATATYPE} & val) {};
+    auto set = [] (const ${DATATYPE} & /*val*/) {};
 
     auto prop = new Property<${DATATYPE}>("${DATATYPE}Property", get, set);
 
@@ -178,7 +178,7 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}_test, instanciateAccessorWith_String_V
 TEST_F(PropertyInstance${CAPITALDATATYPE}_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return ${DATATYPE}();};
-    auto set = [] (const ${DATATYPE} & val) {};
+    auto set = [] (const ${DATATYPE} & /*val*/) {};
     auto accessor = new AccessorGetSet<${DATATYPE}>(get, set);
 
     auto prop = new Property<${DATATYPE}>("${DATATYPE}Property", accessor);
@@ -344,7 +344,7 @@ ${DATATYPE} staticGetter(size_t)
     return ${DATATYPE}();
 }
 
-void staticSetter(size_t, ${DATATYPE} value)
+void staticSetter(size_t, ${DATATYPE} /*value*/)
 {
 }
 }
@@ -355,20 +355,20 @@ void staticSetter(size_t, ${DATATYPE} value)
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return ${DATATYPE}();};
-    auto set = [] (size_t, const ${DATATYPE} & val) {};
+    auto set = [] (size_t, const ${DATATYPE} & /*val*/) {};
 
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", get, set);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", get, set);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
 
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciatePropertyWith_String_StaticGetter_StaticSetter)
 {
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", &staticGetter, &staticSetter);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", &staticGetter, &staticSetter);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
@@ -376,9 +376,9 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciatePropertyWith_Str
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciatePropertyWith_String_Object_ConstGetterConst_SetterConst)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayConstgetterconst, &MyObject<${DATATYPE}>::arraySetterconst);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayConstgetterconst, &MyObject<${DATATYPE}>::arraySetterconst);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;
@@ -388,9 +388,9 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciatePropertyWith_Str
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciatePropertyWith_String_Object_GetterConst_SetterConst)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayGetterconst, &MyObject<${DATATYPE}>::arraySetterconst);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayGetterconst, &MyObject<${DATATYPE}>::arraySetterconst);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;
@@ -400,9 +400,9 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciatePropertyWith_Str
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciatePropertyWith_String_Object_GetterConst_Setter)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayGetterconst, &MyObject<${DATATYPE}>::arraySetter);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayGetterconst, &MyObject<${DATATYPE}>::arraySetter);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;
@@ -416,18 +416,18 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstPropertyWit
 {
     auto get = [] (size_t) {return ${DATATYPE}();};
 
-    auto prop = new PropertyArray<const ${DATATYPE}, 0>("${DATATYPE}Property", get);
+    auto prop = new PropertyArray<const ${DATATYPE}, 1>("${DATATYPE}Property", get);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
 
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstPropertyWith_String_StaticGetter)
 {
-    auto prop = new PropertyArray<const ${DATATYPE}, 0>("${DATATYPE}Property", &staticGetter);
+    auto prop = new PropertyArray<const ${DATATYPE}, 1>("${DATATYPE}Property", &staticGetter);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
@@ -435,9 +435,9 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstPropertyWit
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstPropertyWith_String_Object_ConstGetterConst)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto prop = new PropertyArray<const ${DATATYPE}, 0>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayConstgetterconst);
+    auto prop = new PropertyArray<const ${DATATYPE}, 1>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayConstgetterconst);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;
@@ -447,9 +447,9 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstPropertyWit
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstPropertyWith_String_Object_GetterConst)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto prop = new PropertyArray<const ${DATATYPE}, 0>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayGetterconst);
+    auto prop = new PropertyArray<const ${DATATYPE}, 1>("${DATATYPE}Property", obj, &MyObject<${DATATYPE}>::arrayGetterconst);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;
@@ -462,20 +462,20 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstPropertyWit
 
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_String)
 {
-    auto accessor = new ArrayAccessorValue<${DATATYPE}, 0>();
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto accessor = new ArrayAccessorValue<${DATATYPE}, 1>();
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
 
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_String_Value)
 {
-    auto accessor = new ArrayAccessorValue<${DATATYPE}, 0>(std::array<${DATATYPE}, 0>());
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto accessor = new ArrayAccessorValue<${DATATYPE}, 1>(std::array<${DATATYPE}, 1>());
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
@@ -483,23 +483,23 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_Str
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return ${DATATYPE}();};
-    auto set = [] (size_t, const ${DATATYPE} & val) {};
-    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 0>(get, set);
+    auto set = [] (size_t, const ${DATATYPE} & /*val*/) {};
+    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 1>(get, set);
 
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
 
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_String_StaticGetter_StaticSetter)
 {
-    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 0>(&staticGetter, &staticSetter);
+    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 1>(&staticGetter, &staticSetter);
 
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
@@ -507,10 +507,10 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_Str
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_String_Object_ConstGetterConst_SetterConst)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 0>(obj, &MyObject<${DATATYPE}>::arrayConstgetterconst, &MyObject<${DATATYPE}>::arraySetterconst);
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 1>(obj, &MyObject<${DATATYPE}>::arrayConstgetterconst, &MyObject<${DATATYPE}>::arraySetterconst);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;
@@ -520,10 +520,10 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_Str
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_String_Object_GetterConst_SetterConst)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 0>(obj, &MyObject<${DATATYPE}>::arrayGetterconst, &MyObject<${DATATYPE}>::arraySetterconst);
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 1>(obj, &MyObject<${DATATYPE}>::arrayGetterconst, &MyObject<${DATATYPE}>::arraySetterconst);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;
@@ -533,10 +533,10 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_Str
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_String_Object_GetterConst_Setter)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 0>(obj, &MyObject<${DATATYPE}>::arrayGetterconst, &MyObject<${DATATYPE}>::arraySetter);
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto accessor = new ArrayAccessorGetSet<${DATATYPE}, 1>(obj, &MyObject<${DATATYPE}>::arrayGetterconst, &MyObject<${DATATYPE}>::arraySetter);
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;
@@ -548,20 +548,20 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateAccessorWith_Str
 
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstAccessorWith_String)
 {
-    auto accessor = new ArrayAccessorValue<const ${DATATYPE}, 0>();
-    auto prop = new PropertyArray<const ${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto accessor = new ArrayAccessorValue<const ${DATATYPE}, 1>();
+    auto prop = new PropertyArray<const ${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
 
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstAccessorWith_String_Value)
 {
-    auto accessor = new ArrayAccessorValue<const ${DATATYPE}, 0>(std::array<${DATATYPE}, 0>());
-    auto prop = new PropertyArray<${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto accessor = new ArrayAccessorValue<const ${DATATYPE}, 1>(std::array<${DATATYPE}, 1>());
+    auto prop = new PropertyArray<${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
@@ -569,22 +569,22 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstAccessorWit
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstAccessorWith_String_LambdaGetter)
 {
     auto get = [] (size_t) {return ${DATATYPE}();};
-    auto accessor = new ArrayAccessorGetSet<const ${DATATYPE}, 0>(get);
+    auto accessor = new ArrayAccessorGetSet<const ${DATATYPE}, 1>(get);
 
-    auto prop = new PropertyArray<const ${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto prop = new PropertyArray<const ${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
 
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstAccessorWith_String_StaticGetter)
 {
-    auto accessor = new ArrayAccessorGetSet<const ${DATATYPE}, 0>(&staticGetter);
+    auto accessor = new ArrayAccessorGetSet<const ${DATATYPE}, 1>(&staticGetter);
 
-    auto prop = new PropertyArray<const ${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto prop = new PropertyArray<const ${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
     delete prop;
 }
@@ -592,10 +592,10 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstAccessorWit
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstAccessorWith_String_Object_ConstGetterConst)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto accessor = new ArrayAccessorGetSet<const ${DATATYPE}, 0>(obj, &MyObject<${DATATYPE}>::arrayConstgetterconst);
-    auto prop = new PropertyArray<const ${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto accessor = new ArrayAccessorGetSet<const ${DATATYPE}, 1>(obj, &MyObject<${DATATYPE}>::arrayConstgetterconst);
+    auto prop = new PropertyArray<const ${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;
@@ -605,10 +605,10 @@ TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstAccessorWit
 TEST_F(PropertyInstance${CAPITALDATATYPE}Array_test, instanciateConstAccessorWith_String_Object_GetterConst)
 {
     auto obj = new MyObject<${DATATYPE}>;
-    auto accessor = new ArrayAccessorGetSet<const ${DATATYPE}, 0>(obj, &MyObject<${DATATYPE}>::arrayGetterconst);
-    auto prop = new PropertyArray<const ${DATATYPE}, 0>("${DATATYPE}Property", accessor);
+    auto accessor = new ArrayAccessorGetSet<const ${DATATYPE}, 1>(obj, &MyObject<${DATATYPE}>::arrayGetterconst);
+    auto prop = new PropertyArray<const ${DATATYPE}, 1>("${DATATYPE}Property", accessor);
 
-    ASSERT_EQ(typeid(std::array<${DATATYPE}, 0>), prop->type());
+    ASSERT_EQ(typeid(std::array<${DATATYPE}, 1>), prop->type());
 
 
     delete prop;

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationBoolArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationBoolArray_test.cpp
@@ -27,7 +27,7 @@ bool staticGetter(size_t)
     return bool();
 }
 
-void staticSetter(size_t, bool value)
+void staticSetter(size_t, bool /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, bool value)
 TEST_F(PropertyInstanceBoolArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return bool();};
-    auto set = [] (size_t, const bool & val) {};
+    auto set = [] (size_t, const bool & /*val*/) {};
 
     auto prop = new PropertyArray<bool, 1>("boolProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceBoolArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceBoolArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return bool();};
-    auto set = [] (size_t, const bool & val) {};
+    auto set = [] (size_t, const bool & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<bool, 1>(get, set);
 
     auto prop = new PropertyArray<bool, 1>("boolProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationBool_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationBool_test.cpp
@@ -26,7 +26,7 @@ bool staticGetter()
     return bool();
 }
 
-void staticSetter(bool value)
+void staticSetter(bool /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(bool value)
 TEST_F(PropertyInstanceBool_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return bool();};
-    auto set = [] (const bool & val) {};
+    auto set = [] (const bool & /*val*/) {};
 
     auto prop = new Property<bool>("boolProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceBool_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceBool_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return bool();};
-    auto set = [] (const bool & val) {};
+    auto set = [] (const bool & /*val*/) {};
     auto accessor = new AccessorGetSet<bool>(get, set);
 
     auto prop = new Property<bool>("boolProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationDoubleArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationDoubleArray_test.cpp
@@ -27,7 +27,7 @@ double staticGetter(size_t)
     return double();
 }
 
-void staticSetter(size_t, double value)
+void staticSetter(size_t, double /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, double value)
 TEST_F(PropertyInstanceDoubleArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return double();};
-    auto set = [] (size_t, const double & val) {};
+    auto set = [] (size_t, const double & /*val*/) {};
 
     auto prop = new PropertyArray<double, 1>("doubleProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceDoubleArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceDoubleArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return double();};
-    auto set = [] (size_t, const double & val) {};
+    auto set = [] (size_t, const double & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<double, 1>(get, set);
 
     auto prop = new PropertyArray<double, 1>("doubleProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationDouble_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationDouble_test.cpp
@@ -26,7 +26,7 @@ double staticGetter()
     return double();
 }
 
-void staticSetter(double value)
+void staticSetter(double /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(double value)
 TEST_F(PropertyInstanceDouble_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return double();};
-    auto set = [] (const double & val) {};
+    auto set = [] (const double & /*val*/) {};
 
     auto prop = new Property<double>("doubleProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceDouble_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceDouble_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return double();};
-    auto set = [] (const double & val) {};
+    auto set = [] (const double & /*val*/) {};
     auto accessor = new AccessorGetSet<double>(get, set);
 
     auto prop = new Property<double>("doubleProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationFloatArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationFloatArray_test.cpp
@@ -27,7 +27,7 @@ float staticGetter(size_t)
     return float();
 }
 
-void staticSetter(size_t, float value)
+void staticSetter(size_t, float /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, float value)
 TEST_F(PropertyInstanceFloatArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return float();};
-    auto set = [] (size_t, const float & val) {};
+    auto set = [] (size_t, const float & /*val*/) {};
 
     auto prop = new PropertyArray<float, 1>("floatProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceFloatArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceFloatArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return float();};
-    auto set = [] (size_t, const float & val) {};
+    auto set = [] (size_t, const float & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<float, 1>(get, set);
 
     auto prop = new PropertyArray<float, 1>("floatProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationFloat_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationFloat_test.cpp
@@ -26,7 +26,7 @@ float staticGetter()
     return float();
 }
 
-void staticSetter(float value)
+void staticSetter(float /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(float value)
 TEST_F(PropertyInstanceFloat_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return float();};
-    auto set = [] (const float & val) {};
+    auto set = [] (const float & /*val*/) {};
 
     auto prop = new Property<float>("floatProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceFloat_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceFloat_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return float();};
-    auto set = [] (const float & val) {};
+    auto set = [] (const float & /*val*/) {};
     auto accessor = new AccessorGetSet<float>(get, set);
 
     auto prop = new Property<float>("floatProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt16_TArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt16_TArray_test.cpp
@@ -27,7 +27,7 @@ int16_t staticGetter(size_t)
     return int16_t();
 }
 
-void staticSetter(size_t, int16_t value)
+void staticSetter(size_t, int16_t /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, int16_t value)
 TEST_F(PropertyInstanceInt16_TArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return int16_t();};
-    auto set = [] (size_t, const int16_t & val) {};
+    auto set = [] (size_t, const int16_t & /*val*/) {};
 
     auto prop = new PropertyArray<int16_t, 1>("int16_tProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceInt16_TArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceInt16_TArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return int16_t();};
-    auto set = [] (size_t, const int16_t & val) {};
+    auto set = [] (size_t, const int16_t & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<int16_t, 1>(get, set);
 
     auto prop = new PropertyArray<int16_t, 1>("int16_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt16_T_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt16_T_test.cpp
@@ -26,7 +26,7 @@ int16_t staticGetter()
     return int16_t();
 }
 
-void staticSetter(int16_t value)
+void staticSetter(int16_t /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(int16_t value)
 TEST_F(PropertyInstanceInt16_T_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return int16_t();};
-    auto set = [] (const int16_t & val) {};
+    auto set = [] (const int16_t & /*val*/) {};
 
     auto prop = new Property<int16_t>("int16_tProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceInt16_T_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceInt16_T_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return int16_t();};
-    auto set = [] (const int16_t & val) {};
+    auto set = [] (const int16_t & /*val*/) {};
     auto accessor = new AccessorGetSet<int16_t>(get, set);
 
     auto prop = new Property<int16_t>("int16_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt32_TArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt32_TArray_test.cpp
@@ -27,7 +27,7 @@ int32_t staticGetter(size_t)
     return int32_t();
 }
 
-void staticSetter(size_t, int32_t value)
+void staticSetter(size_t, int32_t /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, int32_t value)
 TEST_F(PropertyInstanceInt32_TArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return int32_t();};
-    auto set = [] (size_t, const int32_t & val) {};
+    auto set = [] (size_t, const int32_t & /*val*/) {};
 
     auto prop = new PropertyArray<int32_t, 1>("int32_tProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceInt32_TArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceInt32_TArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return int32_t();};
-    auto set = [] (size_t, const int32_t & val) {};
+    auto set = [] (size_t, const int32_t & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<int32_t, 1>(get, set);
 
     auto prop = new PropertyArray<int32_t, 1>("int32_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt32_T_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt32_T_test.cpp
@@ -26,7 +26,7 @@ int32_t staticGetter()
     return int32_t();
 }
 
-void staticSetter(int32_t value)
+void staticSetter(int32_t /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(int32_t value)
 TEST_F(PropertyInstanceInt32_T_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return int32_t();};
-    auto set = [] (const int32_t & val) {};
+    auto set = [] (const int32_t & /*val*/) {};
 
     auto prop = new Property<int32_t>("int32_tProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceInt32_T_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceInt32_T_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return int32_t();};
-    auto set = [] (const int32_t & val) {};
+    auto set = [] (const int32_t & /*val*/) {};
     auto accessor = new AccessorGetSet<int32_t>(get, set);
 
     auto prop = new Property<int32_t>("int32_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt64_TArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt64_TArray_test.cpp
@@ -27,7 +27,7 @@ int64_t staticGetter(size_t)
     return int64_t();
 }
 
-void staticSetter(size_t, int64_t value)
+void staticSetter(size_t, int64_t /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, int64_t value)
 TEST_F(PropertyInstanceInt64_TArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return int64_t();};
-    auto set = [] (size_t, const int64_t & val) {};
+    auto set = [] (size_t, const int64_t & /*val*/) {};
 
     auto prop = new PropertyArray<int64_t, 1>("int64_tProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceInt64_TArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceInt64_TArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return int64_t();};
-    auto set = [] (size_t, const int64_t & val) {};
+    auto set = [] (size_t, const int64_t & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<int64_t, 1>(get, set);
 
     auto prop = new PropertyArray<int64_t, 1>("int64_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt64_T_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt64_T_test.cpp
@@ -26,7 +26,7 @@ int64_t staticGetter()
     return int64_t();
 }
 
-void staticSetter(int64_t value)
+void staticSetter(int64_t /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(int64_t value)
 TEST_F(PropertyInstanceInt64_T_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return int64_t();};
-    auto set = [] (const int64_t & val) {};
+    auto set = [] (const int64_t & /*val*/) {};
 
     auto prop = new Property<int64_t>("int64_tProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceInt64_T_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceInt64_T_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return int64_t();};
-    auto set = [] (const int64_t & val) {};
+    auto set = [] (const int64_t & /*val*/) {};
     auto accessor = new AccessorGetSet<int64_t>(get, set);
 
     auto prop = new Property<int64_t>("int64_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt8_TArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt8_TArray_test.cpp
@@ -27,7 +27,7 @@ int8_t staticGetter(size_t)
     return int8_t();
 }
 
-void staticSetter(size_t, int8_t value)
+void staticSetter(size_t, int8_t /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, int8_t value)
 TEST_F(PropertyInstanceInt8_TArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return int8_t();};
-    auto set = [] (size_t, const int8_t & val) {};
+    auto set = [] (size_t, const int8_t & /*val*/) {};
 
     auto prop = new PropertyArray<int8_t, 1>("int8_tProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceInt8_TArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceInt8_TArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return int8_t();};
-    auto set = [] (size_t, const int8_t & val) {};
+    auto set = [] (size_t, const int8_t & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<int8_t, 1>(get, set);
 
     auto prop = new PropertyArray<int8_t, 1>("int8_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt8_T_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationInt8_T_test.cpp
@@ -26,7 +26,7 @@ int8_t staticGetter()
     return int8_t();
 }
 
-void staticSetter(int8_t value)
+void staticSetter(int8_t /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(int8_t value)
 TEST_F(PropertyInstanceInt8_T_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return int8_t();};
-    auto set = [] (const int8_t & val) {};
+    auto set = [] (const int8_t & /*val*/) {};
 
     auto prop = new Property<int8_t>("int8_tProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceInt8_T_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceInt8_T_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return int8_t();};
-    auto set = [] (const int8_t & val) {};
+    auto set = [] (const int8_t & /*val*/) {};
     auto accessor = new AccessorGetSet<int8_t>(get, set);
 
     auto prop = new Property<int8_t>("int8_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationStringArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationStringArray_test.cpp
@@ -27,7 +27,7 @@ string staticGetter(size_t)
     return string();
 }
 
-void staticSetter(size_t, string value)
+void staticSetter(size_t, string /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, string value)
 TEST_F(PropertyInstanceStringArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return string();};
-    auto set = [] (size_t, const string & val) {};
+    auto set = [] (size_t, const string & /*val*/) {};
 
     auto prop = new PropertyArray<string, 1>("stringProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceStringArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceStringArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return string();};
-    auto set = [] (size_t, const string & val) {};
+    auto set = [] (size_t, const string & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<string, 1>(get, set);
 
     auto prop = new PropertyArray<string, 1>("stringProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationString_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationString_test.cpp
@@ -26,7 +26,7 @@ string staticGetter()
     return string();
 }
 
-void staticSetter(string value)
+void staticSetter(string /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(string value)
 TEST_F(PropertyInstanceString_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return string();};
-    auto set = [] (const string & val) {};
+    auto set = [] (const string & /*val*/) {};
 
     auto prop = new Property<string>("stringProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceString_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceString_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return string();};
-    auto set = [] (const string & val) {};
+    auto set = [] (const string & /*val*/) {};
     auto accessor = new AccessorGetSet<string>(get, set);
 
     auto prop = new Property<string>("stringProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint16_TArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint16_TArray_test.cpp
@@ -27,7 +27,7 @@ uint16_t staticGetter(size_t)
     return uint16_t();
 }
 
-void staticSetter(size_t, uint16_t value)
+void staticSetter(size_t, uint16_t /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, uint16_t value)
 TEST_F(PropertyInstanceUint16_TArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return uint16_t();};
-    auto set = [] (size_t, const uint16_t & val) {};
+    auto set = [] (size_t, const uint16_t & /*val*/) {};
 
     auto prop = new PropertyArray<uint16_t, 1>("uint16_tProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceUint16_TArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceUint16_TArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return uint16_t();};
-    auto set = [] (size_t, const uint16_t & val) {};
+    auto set = [] (size_t, const uint16_t & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<uint16_t, 1>(get, set);
 
     auto prop = new PropertyArray<uint16_t, 1>("uint16_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint16_T_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint16_T_test.cpp
@@ -26,7 +26,7 @@ uint16_t staticGetter()
     return uint16_t();
 }
 
-void staticSetter(uint16_t value)
+void staticSetter(uint16_t /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(uint16_t value)
 TEST_F(PropertyInstanceUint16_T_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return uint16_t();};
-    auto set = [] (const uint16_t & val) {};
+    auto set = [] (const uint16_t & /*val*/) {};
 
     auto prop = new Property<uint16_t>("uint16_tProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceUint16_T_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceUint16_T_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return uint16_t();};
-    auto set = [] (const uint16_t & val) {};
+    auto set = [] (const uint16_t & /*val*/) {};
     auto accessor = new AccessorGetSet<uint16_t>(get, set);
 
     auto prop = new Property<uint16_t>("uint16_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint32_TArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint32_TArray_test.cpp
@@ -27,7 +27,7 @@ uint32_t staticGetter(size_t)
     return uint32_t();
 }
 
-void staticSetter(size_t, uint32_t value)
+void staticSetter(size_t, uint32_t /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, uint32_t value)
 TEST_F(PropertyInstanceUint32_TArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return uint32_t();};
-    auto set = [] (size_t, const uint32_t & val) {};
+    auto set = [] (size_t, const uint32_t & /*val*/) {};
 
     auto prop = new PropertyArray<uint32_t, 1>("uint32_tProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceUint32_TArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceUint32_TArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return uint32_t();};
-    auto set = [] (size_t, const uint32_t & val) {};
+    auto set = [] (size_t, const uint32_t & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<uint32_t, 1>(get, set);
 
     auto prop = new PropertyArray<uint32_t, 1>("uint32_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint32_T_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint32_T_test.cpp
@@ -26,7 +26,7 @@ uint32_t staticGetter()
     return uint32_t();
 }
 
-void staticSetter(uint32_t value)
+void staticSetter(uint32_t /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(uint32_t value)
 TEST_F(PropertyInstanceUint32_T_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return uint32_t();};
-    auto set = [] (const uint32_t & val) {};
+    auto set = [] (const uint32_t & /*val*/) {};
 
     auto prop = new Property<uint32_t>("uint32_tProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceUint32_T_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceUint32_T_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return uint32_t();};
-    auto set = [] (const uint32_t & val) {};
+    auto set = [] (const uint32_t & /*val*/) {};
     auto accessor = new AccessorGetSet<uint32_t>(get, set);
 
     auto prop = new Property<uint32_t>("uint32_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint64_TArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint64_TArray_test.cpp
@@ -27,7 +27,7 @@ uint64_t staticGetter(size_t)
     return uint64_t();
 }
 
-void staticSetter(size_t, uint64_t value)
+void staticSetter(size_t, uint64_t /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, uint64_t value)
 TEST_F(PropertyInstanceUint64_TArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return uint64_t();};
-    auto set = [] (size_t, const uint64_t & val) {};
+    auto set = [] (size_t, const uint64_t & /*val*/) {};
 
     auto prop = new PropertyArray<uint64_t, 1>("uint64_tProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceUint64_TArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceUint64_TArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return uint64_t();};
-    auto set = [] (size_t, const uint64_t & val) {};
+    auto set = [] (size_t, const uint64_t & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<uint64_t, 1>(get, set);
 
     auto prop = new PropertyArray<uint64_t, 1>("uint64_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint64_T_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint64_T_test.cpp
@@ -26,7 +26,7 @@ uint64_t staticGetter()
     return uint64_t();
 }
 
-void staticSetter(uint64_t value)
+void staticSetter(uint64_t /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(uint64_t value)
 TEST_F(PropertyInstanceUint64_T_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return uint64_t();};
-    auto set = [] (const uint64_t & val) {};
+    auto set = [] (const uint64_t & /*val*/) {};
 
     auto prop = new Property<uint64_t>("uint64_tProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceUint64_T_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceUint64_T_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return uint64_t();};
-    auto set = [] (const uint64_t & val) {};
+    auto set = [] (const uint64_t & /*val*/) {};
     auto accessor = new AccessorGetSet<uint64_t>(get, set);
 
     auto prop = new Property<uint64_t>("uint64_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint8_TArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint8_TArray_test.cpp
@@ -27,7 +27,7 @@ uint8_t staticGetter(size_t)
     return uint8_t();
 }
 
-void staticSetter(size_t, uint8_t value)
+void staticSetter(size_t, uint8_t /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, uint8_t value)
 TEST_F(PropertyInstanceUint8_TArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return uint8_t();};
-    auto set = [] (size_t, const uint8_t & val) {};
+    auto set = [] (size_t, const uint8_t & /*val*/) {};
 
     auto prop = new PropertyArray<uint8_t, 1>("uint8_tProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceUint8_TArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceUint8_TArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return uint8_t();};
-    auto set = [] (size_t, const uint8_t & val) {};
+    auto set = [] (size_t, const uint8_t & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<uint8_t, 1>(get, set);
 
     auto prop = new PropertyArray<uint8_t, 1>("uint8_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint8_T_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationUint8_T_test.cpp
@@ -26,7 +26,7 @@ uint8_t staticGetter()
     return uint8_t();
 }
 
-void staticSetter(uint8_t value)
+void staticSetter(uint8_t /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(uint8_t value)
 TEST_F(PropertyInstanceUint8_T_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return uint8_t();};
-    auto set = [] (const uint8_t & val) {};
+    auto set = [] (const uint8_t & /*val*/) {};
 
     auto prop = new Property<uint8_t>("uint8_tProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceUint8_T_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceUint8_T_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return uint8_t();};
-    auto set = [] (const uint8_t & val) {};
+    auto set = [] (const uint8_t & /*val*/) {};
     auto accessor = new AccessorGetSet<uint8_t>(get, set);
 
     auto prop = new Property<uint8_t>("uint8_tProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationVariantArray_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationVariantArray_test.cpp
@@ -27,7 +27,7 @@ Variant staticGetter(size_t)
     return Variant();
 }
 
-void staticSetter(size_t, Variant value)
+void staticSetter(size_t, Variant /*value*/)
 {
 }
 }
@@ -38,7 +38,7 @@ void staticSetter(size_t, Variant value)
 TEST_F(PropertyInstanceVariantArray_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return Variant();};
-    auto set = [] (size_t, const Variant & val) {};
+    auto set = [] (size_t, const Variant & /*val*/) {};
 
     auto prop = new PropertyArray<Variant, 1>("VariantProperty", get, set);
 
@@ -166,7 +166,7 @@ TEST_F(PropertyInstanceVariantArray_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceVariantArray_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] (size_t) {return Variant();};
-    auto set = [] (size_t, const Variant & val) {};
+    auto set = [] (size_t, const Variant & /*val*/) {};
     auto accessor = new ArrayAccessorGetSet<Variant, 1>(get, set);
 
     auto prop = new PropertyArray<Variant, 1>("VariantProperty", accessor);

--- a/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationVariant_test.cpp
+++ b/source/tests/reflectionzeug-test/propertyInstanciationTests/PropertyInstanciationVariant_test.cpp
@@ -26,7 +26,7 @@ Variant staticGetter()
     return Variant();
 }
 
-void staticSetter(Variant value)
+void staticSetter(Variant /*value*/)
 {
 }
 }
@@ -37,7 +37,7 @@ void staticSetter(Variant value)
 TEST_F(PropertyInstanceVariant_test, instanciatePropertyWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return Variant();};
-    auto set = [] (const Variant & val) {};
+    auto set = [] (const Variant & /*val*/) {};
 
     auto prop = new Property<Variant>("VariantProperty", get, set);
 
@@ -165,7 +165,7 @@ TEST_F(PropertyInstanceVariant_test, instanciateAccessorWith_String_Value)
 TEST_F(PropertyInstanceVariant_test, instanciateAccessorWith_String_LambdaGetter_LambdaSetter)
 {
     auto get = [] () {return Variant();};
-    auto set = [] (const Variant & val) {};
+    auto set = [] (const Variant & /*val*/) {};
     auto accessor = new AccessorGetSet<Variant>(get, set);
 
     auto prop = new Property<Variant>("VariantProperty", accessor);

--- a/source/tests/threadingzeug-test/parallel_for_test.cpp
+++ b/source/tests/threadingzeug-test/parallel_for_test.cpp
@@ -79,7 +79,7 @@ TEST_F(parallelFor_test, SizeTCompilation)
     size_t start = 0;
     size_t end = 1;
 
-    parallelFor(start, end, [] (size_t i) {
+    parallelFor(start, end, [] (size_t /*i*/) {
         SUCCEED();
     });
 }
@@ -112,7 +112,7 @@ TEST_F(parallelFor_test, Uint32Compilation)
     std::uint32_t start = 0;
     std::uint32_t end = 1;
 
-    parallelFor(start, end, [] (std::uint32_t i) {
+    parallelFor(start, end, [] (std::uint32_t /*i*/) {
         SUCCEED();
     });
 }
@@ -122,7 +122,7 @@ TEST_F(parallelFor_test, Uint64Compilation)
     std::uint64_t start = 0;
     std::uint64_t end = 1;
 
-    parallelFor(start, end, [] (std::uint64_t i) {
+    parallelFor(start, end, [] (std::uint64_t /*i*/) {
         SUCCEED();
     });
 }
@@ -132,7 +132,7 @@ TEST_F(parallelFor_test, UintCompilation)
     unsigned int start = 0;
     unsigned int end = 1;
 
-    parallelFor(start, end, [] (unsigned int i) {
+    parallelFor(start, end, [] (unsigned int /*i*/) {
         SUCCEED();
     });
 }

--- a/source/widgetzeug/include/widgetzeug/RGBABrush.hpp
+++ b/source/widgetzeug/include/widgetzeug/RGBABrush.hpp
@@ -35,6 +35,6 @@ inline const QBrush RGBABrush(
         }
 
     return QBrush(image);
-};
+}
 
 } // namespace widgetzeug

--- a/source/widgetzeug/source/ColorSchemeGraphicsItem.cpp
+++ b/source/widgetzeug/source/ColorSchemeGraphicsItem.cpp
@@ -236,9 +236,9 @@ QRectF ColorSchemeGraphicsItem::boundingRect() const
 }
 
 void ColorSchemeGraphicsItem::paint(
-    QPainter * painter, 
-    const QStyleOptionGraphicsItem * option, 
-    QWidget * widget)
+    QPainter * /*painter*/, 
+    const QStyleOptionGraphicsItem * /*option*/, 
+    QWidget * /*widget*/)
 {
 }
 
@@ -258,7 +258,7 @@ void ColorSchemeGraphicsItem::hoverLeaveEvent(QGraphicsSceneHoverEvent * event)
     update();
 }
 
-void ColorSchemeGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent * event)
+void ColorSchemeGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent * /*event*/)
 {
     setSelected(true, true);
 }

--- a/source/widgetzeug/source/ColorSchemeGraphicsItemGroup.cpp
+++ b/source/widgetzeug/source/ColorSchemeGraphicsItemGroup.cpp
@@ -33,8 +33,8 @@ QRectF ColorSchemeGraphicsItemGroup::boundingRect() const
     return QRect();
 }
 
-void ColorSchemeGraphicsItemGroup::paint(QPainter * painter, 
-    const QStyleOptionGraphicsItem * option, QWidget * widget)
+void ColorSchemeGraphicsItemGroup::paint(QPainter * /*painter*/, 
+    const QStyleOptionGraphicsItem * /*option*/, QWidget * /*widget*/)
 {
 }
 

--- a/source/widgetzeug/source/ColorSchemeWidget.cpp
+++ b/source/widgetzeug/source/ColorSchemeWidget.cpp
@@ -12,7 +12,7 @@
 namespace widgetzeug
 {
 
-ColorSchemeWidget::ColorSchemeWidget(QWidget * parent)
+ColorSchemeWidget::ColorSchemeWidget(QWidget * /*parent*/)
 : m_ui{ new Ui_ColorSchemeWidget() }
 , m_scheme{ nullptr }
 {

--- a/source/widgetzeug/source/DataLinkWidget.cpp
+++ b/source/widgetzeug/source/DataLinkWidget.cpp
@@ -25,7 +25,7 @@ public:
     {
     }
 
-    State validate(QString & input, int & pos) const override
+    State validate(QString & input, int & /*pos*/) const override
     {
         const auto fileInfo = QFileInfo{input};
 
@@ -37,7 +37,7 @@ public:
 };
 
 
-DataLinkWidget::DataLinkWidget(QWidget * parent)
+DataLinkWidget::DataLinkWidget(QWidget * /*parent*/)
 :   m_watcher{new QFileSystemWatcher{this}}
 ,   m_watchFile{false}
 ,   m_ui{make_unique<Ui_DataLinkWidget>()}

--- a/source/widgetzeug/source/DpiAwareGraphicsView.cpp
+++ b/source/widgetzeug/source/DpiAwareGraphicsView.cpp
@@ -28,7 +28,7 @@ qreal DpiAwareGraphicsView::devicePixelRatio() const
     return DpiAware::devicePixelRatio(this);
 }
 
-void DpiAwareGraphicsView::showEvent(QShowEvent * event)
+void DpiAwareGraphicsView::showEvent(QShowEvent * /*event*/)
 {
     auto window = handle(*this);
 

--- a/source/widgetzeug/source/DpiAwareWidget.cpp
+++ b/source/widgetzeug/source/DpiAwareWidget.cpp
@@ -23,7 +23,7 @@ qreal DpiAwareWidget::devicePixelRatio() const
     return DpiAware::devicePixelRatio(this);
 }
 
-void DpiAwareWidget::showEvent(QShowEvent * event)
+void DpiAwareWidget::showEvent(QShowEvent * /*event*/)
 {
     auto window = handle(*this);
 

--- a/source/widgetzeug/source/ECMA26251_Completer.cpp
+++ b/source/widgetzeug/source/ECMA26251_Completer.cpp
@@ -42,7 +42,7 @@ namespace
 ECMA26251Completer::ECMA26251Completer()
 {
     registerWords(ECMA_Keywords);
-};
+}
 
 ECMA26251Completer::~ECMA26251Completer()
 {

--- a/source/widgetzeug/source/ECMA26251_SyntaxHighlighter.cpp
+++ b/source/widgetzeug/source/ECMA26251_SyntaxHighlighter.cpp
@@ -69,7 +69,7 @@ ECMA26251SyntaxHighlight::ECMA26251SyntaxHighlight()
 
     addPattern("//[.]*[^\\n]*(\\n|$)", commentFormat);
     addMultiLinePattern("/\\*", "\\*/", commentFormat);
-};
+}
 
 ECMA26251SyntaxHighlight::~ECMA26251SyntaxHighlight()
 {

--- a/source/widgetzeug/source/MessageWidget.cpp
+++ b/source/widgetzeug/source/MessageWidget.cpp
@@ -39,25 +39,28 @@ MessageWidget::~MessageWidget()
 
 void MessageWidget::print(
     const QtMsgType type
-,   const QMessageLogContext & context
+,   const QMessageLogContext & /*context*/
+#ifdef _DEBUG
+    context
+#endif
 ,   const QDateTime & timestamp
 ,   const QString & message)
 {
 #ifdef _NDEBUG
-	const QString t(timestamp.toString("hh:mm:ss"));
+    const QString t(timestamp.toString("hh:mm:ss"));
 #else
-	const QString t(timestamp.toString("hh:mm:ss:zzz"));
+    const QString t(timestamp.toString("hh:mm:ss:zzz"));
 #endif
-	//const QString timestamp(entry.timestamp().toString("hh:mm:ss"));
+    //const QString timestamp(entry.timestamp().toString("hh:mm:ss"));
 
     QString html;
-	switch (type)
-	{
+    switch (type)
+    {
     case QtMsgType::QtDebugMsg:
 #ifdef _DEBUG
         html = QString("%1 %2(%3): %4").arg(t).arg(context.file).arg(context.line).arg(message);
 #else
-		html = QString("%1: %2").arg(t).arg(message);
+        html = QString("%1: %2").arg(t).arg(message);
 #endif
 		break;
 


### PR DESCRIPTION
Fix compilation warnings, except of those thrown by the external duktape library.

This also re-adds the custom cmake target for calling the python script to generate the property instanciation tests.