### PR TITLE
Add global namespace option for scripting

### DIFF
--- a/source/scriptzeug/include/scriptzeug/ScriptContext.h
+++ b/source/scriptzeug/include/scriptzeug/ScriptContext.h
@@ -64,6 +64,27 @@ public:
 
     /**
     *  @brief
+    *    Set global namespace
+    *
+    *  @param[in] name
+    *    Namespace at which global objects are registered
+    *
+    *  @remarks
+    *    If set, objects are not registered globally but into
+    *    an object with the given name. E.g., if the global
+    *    namespace is 'myapp', registerObject(obj) can be
+    *    accessed via 'myapp.obj' instead of 'obj'.
+    *
+    *    Some backends, such as the Qml scripting backend,
+    *    may require a global namespace, since they do not
+    *    allow to modify the global object. In this case,
+    *    setGlobalNamespace() can be used to make other
+    *    backends compatible.
+    */
+    void setGlobalNamespace(const std::string & name);
+
+    /**
+    *  @brief
     *    Expose object to scripting
     *
     *  @param[in] obj

--- a/source/scriptzeug/include/scriptzeug/backend/AbstractScriptContext.h
+++ b/source/scriptzeug/include/scriptzeug/backend/AbstractScriptContext.h
@@ -54,6 +54,17 @@ public:
 
     /**
     *  @brief
+    *    Set global namespace
+    *
+    *  @param[in] name
+    *    Namespace at which global objects are registered
+    *
+    *  @see ScriptContext::setGlobalNamespace
+    */
+    virtual void setGlobalNamespace(const std::string & name) = 0;
+
+    /**
+    *  @brief
     *    Expose object to scripting
     *
     *  @param[in] obj

--- a/source/scriptzeug/source/ScriptContext.cpp
+++ b/source/scriptzeug/source/ScriptContext.cpp
@@ -41,6 +41,14 @@ ScriptContext::~ScriptContext()
     delete m_backend;
 }
 
+void ScriptContext::setGlobalNamespace(const std::string & name)
+{
+    if (m_backend)
+    {
+        m_backend->setGlobalNamespace(name);
+    }
+}
+
 void ScriptContext::registerObject(reflectionzeug::PropertyGroup * obj)
 {
     if (m_backend)

--- a/source/scriptzeug/source/backend-duktape/DuktapeScriptContext.h
+++ b/source/scriptzeug/source/backend-duktape/DuktapeScriptContext.h
@@ -4,6 +4,8 @@
 
 #include "duktape-1.4.0/duktape.h"
 
+#include <string>
+
 #include <scriptzeug/backend/AbstractScriptContext.h>
 
 
@@ -32,6 +34,7 @@ public:
 
     // Virtual AbstractScriptContext functions
     virtual void initialize(ScriptContext * scriptContext) override;
+    virtual void setGlobalNamespace(const std::string & name) override;
     virtual void registerObject(reflectionzeug::PropertyGroup * obj) override;
     virtual void unregisterObject(reflectionzeug::PropertyGroup * obj) override;
     virtual reflectionzeug::Variant evaluate(const std::string & code) override;
@@ -42,7 +45,8 @@ protected:
 
 
 protected:
-    duk_context * m_context; ///< Duktape context
+    duk_context * m_context;    ///< Duktape context
+    std::string   m_namespace;  ///< Global namespace
 };
 
 


### PR DESCRIPTION
Add possibility to put objects into a namespace instead of the global object. This is useful to make other scripting backends compatible with the QtQuick backend, which must use a global namespace.

Please review the duktape implementation!