### PR TITLE
Fix signal call order issue in FilePathEditor

### DIFF
--- a/source/propertyguizeug/source/FilePathEditor.cpp
+++ b/source/propertyguizeug/source/FilePathEditor.cpp
@@ -39,7 +39,7 @@ FilePathEditor::FilePathEditor(Property<FilePath> * property, QWidget * parent)
     
     using StringActivatedPtr = void (QCompleter::*)(const QString &);
     connect(completer, static_cast<StringActivatedPtr>(&QCompleter::activated),
-            this, &FilePathEditor::handleItemActivated);
+            this, &FilePathEditor::handleItemActivated, Qt::QueuedConnection);
     
     connect(m_lineEdit, &QLineEdit::selectionChanged, 
         [this]()


### PR DESCRIPTION
Problem:  In the source code of `QLineEdit`, the signal `QCompleter::activated` is connected directly to `QLineEdit::setText` to fill the line edit with the activated item text; however, `FilePathEditor` connects to `QCompleter::activated` as well, opening a file dialog in case the item `Open File Dialog ...` is selected and finally calling `QLineEdit::setText`, too.

The text contained in the line edit depends on the order the slots are called when emitting `QCompleter::activated`: if the `FilePathEditor` slot is called first, the file path returned from the file dialog is entered in the line edit, only to be overwritten immediately with `Open File Dialog ...` when the `QLineEdit::setText` slot is called subsequently.

Solution: use a `QueuedConnection` for `FilePathEditor::handleItemActivated` to defer the call and ensure it is called after `QLineEdit::setText`.